### PR TITLE
功能: 重新設計圖層結構和按鍵綁定

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -8,6 +8,16 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
+// Layers
+
+#define Main        0
+#define Win         1
+#define WinFN       2
+#define WinMedia    3
+#define Mac         4
+#define MacFN       5
+#define MacMedia    6
+
 / {
     macros {
         fpc_id: fpc_id {
@@ -77,88 +87,88 @@
     keymap {
         compatible = "zmk,keymap";
 
-        login {
-            // ------------------------------------------------------------------------------------------------------------
-            // | BTCLR | BT1 | BT2 |  BT3 |  BT4 |  BT5 |                   |      |       |       |      |       |       |
-            // |  F1   |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8   |  F9   |  F10 |  F11  |  F12  |
-            // |   `   |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   ~   |
-            // |       |     |     |      |      |      |        |  |       |      |  _    |  +    |  {   |   }   |  "|"  |
-            //                     |      |      |      |        |  |       |      |       |       |
-
-            display-name = "win";
+        main_layer {
+            display-name = "Main";
+            label = "Main";
             bindings = <
-&bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4                              &fpc_id  &fpc_pw  &kp LG(L)  &excel_pw  &kp LC(LA(DELETE))  &none
-&none       &none         &none         &none         &none         &none                                     &to 2    &none    &none      &none      &none               &none
-&none       &none         &none         &none         &none         &none                                     &none    &none    &none      &none      &none               &none
-&none       &none         &none         &none         &none         &none         &sys_reset     &sys_reset   &none    &none    &none      &none      &none               &none
-                                        &none         &none         &none         &bootloader    &bootloader  &none    &none    &none
+&bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4                              &fpc_id     &fpc_pw  &kp LG(L)  &excel_pw  &kp LC(LA(DELETE))  &none
+&none       &none         &none         &none         &none         &none                                     &none       &none    &none      &none      &none               &none
+&none       &none         &none         &none         &none         &none                                     &none       &none    &none      &none      &none               &none
+&none       &none         &none         &none         &none         &sys_reset    &to Win        &to Mac      &sys_reset  &none    &none      &none      &none               &none
+                                        &none         &none         &none         &bootloader    &bootloader  &none       &none    &none
             >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
 
-        fn_no_symbol {
-            // ------------------------------------------------------------------------------------------------------------
-            // |  ESC  |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |   `   |
-            // |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |   -   |
-            // |  CTRL |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
-            // | SHIFT |  Z  |  X  |  C   |  V   |  B   |   "["  |  |  "]"  |  N   |  M    |  ,    |  .   |   /   | SHIFT |
-            //                     | ALT  | GUI  | LOWER|  SPACE |  | ENTER | RAISE| BSPC  | GUI   |
-
-            display-name = "win";
+        windows_layer {
+            display-name = "Windows";
+            label = "Win";
             bindings = <
-&kp ESC    &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                          &screenshot_win  &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
-&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                     &kp N7           &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
-&kp TILDE  &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                           &kp N4           &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
-&kp LSHFT  &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &kp BSLH       &kp SEMI  &kp N1           &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
-                                           &kp LCTRL     &none                 &kp SQT                &lt 2 COMMA    &kp DOT   &none            &kp N0     &kp FSLH
+&kp GRAVE  &kp N1  &kp N2  &kp N3  &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8     &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E   &kp R     &kp T                            &kp Y     &kp U     &kp I      &kp O    &kp P     &kp BSLH
+&kp LSHFT  &kp A   &kp S   &kp D   &kp F     &kp G                            &kp H     &kp J     &kp K      &kp L    &kp SEMI  &kp SQT
+&kp LCTRL  &kp Z   &kp X   &kp C   &kp V     &kp B     &to WinFN    &kp RBKT  &kp N     &kp M     &kp COMMA  &kp DOT  &kp FSLH  &kp LSHFT
+                           &to FN  &kp LGUI  &kp LALT  &kp SPACE    &kp RET   &mo Main  &kp BSPC  &kp DEL
             >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
 
-        win {
-            // ------------------------------------------------------------------------------------------------------------
-            // |       |     |     |      |      |      |                   |      |       |       |      |       |       |
-            // |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |   7   |   8   |  9   |   0   |       |
-            // |   F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |      |   <-  |   v   |  ^   |  ->   |       |
-            // |   F7  |  F8 |  F9 |  F10 |  F11 |  F12 |        |  |       |  +   |   -   |   =   |  [   |   ]   |   \   |
-            //                     |      |      |      |        |  |       |      |       |       |
-
-            display-name = "win";
+        win_fn_layer {
+            display-name = "WinFN";
+            label = "WinFN";
             bindings = <
-&kp GRAVE  &kp N1  &kp N2  &kp N3  &kp N4    &kp N5                           &kp N6  &kp N7    &kp N8     &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E   &kp R     &kp T                            &kp Y   &kp U     &kp I      &kp O    &kp P     &kp BSLH
-&kp LSHFT  &kp A   &kp S   &kp D   &kp F     &kp G                            &kp H   &kp J     &kp K      &kp L    &kp SEMI  &kp SQT
-&kp LCTRL  &kp Z   &kp X   &kp C   &kp V     &kp B     &kp LBKT     &kp RBKT  &kp N   &kp M     &kp COMMA  &kp DOT  &kp FSLH  &kp LSHFT
-                           &to 1   &kp LGUI  &kp LALT  &kp SPACE    &kp RET   &mo 0   &kp BSPC  &kp DEL
+&kp ESC    &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                           &screenshot_win  &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
+&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                      &kp N7           &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
+&kp TILDE  &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                            &kp N4           &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
+&kp LSHFT  &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &to WinMedia    &kp SEMI  &kp N1           &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
+                                           &kp LCTRL     &none                 &kp SQT                &kp COMMA       &kp DOT   &to Main         &kp N0     &kp FSLH
             >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
 
-        media {
+        win_media_layer {
+            display-name = "WinMedia";
+            label = "WinMedia";
             bindings = <
-&kp C_BRI_MIN  &kp C_BRI_DN  &kp C_BRI_AUTO  &kp C_BRI_UP  &kp C_BRI_MAX  &none                  &none  &none  &none  &none  &none  &none
-&none          &kp C_VOL_DN  &kp C_MUTE      &kp C_VOL_UP  &none          &none                  &none  &none  &none  &none  &none  &none
-&kp C_PREV     &kp C_RW      &kp C_PP        &kp C_FF      &kp C_NEXT     &none                  &none  &none  &none  &none  &none  &none
-&none          &none         &none           &none         &none          &none  &to 2    &none  &none  &none  &none  &none  &none  &none
-                                             &none         &none          &none  &none    &none  &none  &none  &none
+&kp C_BRI_MIN  &kp C_BRI_DN  &kp C_BRI_AUTO  &kp C_BRI_UP  &kp C_BRI_MAX  &none                       &none  &none  &none  &none  &none  &none
+&none          &kp C_VOL_DN  &kp C_MUTE      &kp C_VOL_UP  &none          &none                       &none  &none  &none  &none  &none  &none
+&kp C_PREV     &kp C_RW      &kp C_PP        &kp C_FF      &kp C_NEXT     &none                       &none  &none  &none  &none  &none  &none
+&none          &none         &none           &none         &none          &none  &to Win    &to Main  &none  &none  &none  &none  &none  &none
+                                             &none         &none          &none  &none      &none     &none  &none  &none
             >;
-
-            label = "media";
         };
 
-        mac {
+        mac_layer {
+            display-name = "Mac";
+            label = "Mac";
             bindings = <
 &kp ESC    &kp N1  &kp N2  &kp N3     &kp N4    &kp N5                                      &kp N6         &kp N7  &kp N8      &kp N9   &kp N0    &kp UP
 &kp TAB    &kp Q   &kp W   &kp E      &kp R     &kp T                                       &kp Y          &kp U   &kp I       &kp O    &kp P     &kp LEFT
 &kp LCTRL  &kp A   &kp S   &kp D      &kp F     &kp G                                       &kp H          &kp J   &kp K       &kp L    &kp SEMI  &kp RIGHT
-&kp LCTRL  &kp Z   &kp X   &kp C      &kp V     &kp B     &to 1        &screenshot_sel_mac  &kp N          &kp M   &kp COMMA   &kp DOT  &kp FSLH  &kp DOWN
+&kp LCTRL  &kp Z   &kp X   &kp C      &kp V     &kp B     &to MacFN    &screenshot_sel_mac  &kp N          &kp M   &kp COMMA   &kp DOT  &kp FSLH  &kp DOWN
                            &kp LCTRL  &kp LALT  &kp LGUI  &kp SPACE    &kp RET              &kp BACKSPACE  &trans  &kp DELETE
             >;
+        };
 
-            label = "mac";
+        mac_fn_layer {
+            display-name = "MacFN";
+            label = "MacFN";
+            bindings = <
+&kp ESC    &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                           &screenshot_win  &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
+&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                      &kp N7           &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
+&kp TILDE  &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                            &kp N4           &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
+&kp LSHFT  &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &to MacMedia    &kp SEMI  &kp N1           &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
+                                           &kp LCTRL     &none                 &kp SQT                &kp COMMA       &kp DOT   &to Main         &kp N0     &kp FSLH
+            >;
+        };
+
+        mac_media_layer {
+            display-name = "MacMedia";
+            label = "MacMedia";
+            bindings = <
+&kp C_BRI_MIN  &kp C_BRI_DN  &kp C_BRI_AUTO  &kp C_BRI_UP  &kp C_BRI_MAX  &none                       &none  &none  &none  &none  &none  &none
+&none          &kp C_VOL_DN  &kp C_MUTE      &kp C_VOL_UP  &none          &none                       &none  &none  &none  &none  &none  &none
+&kp C_PREV     &kp C_RW      &kp C_PP        &kp C_FF      &kp C_NEXT     &none                       &none  &none  &none  &none  &none  &none
+&none          &none         &none           &none         &none          &none  &to Mac    &to Main  &none  &none  &none  &none  &none  &none
+                                             &none         &none          &none  &none      &none     &none  &none  &none
+            >;
         };
     };
 };


### PR DESCRIPTION
- 新增圖層 Main、Win、WinFN、WinMedia、Mac、MacFN 和 MacMedia
- 更新主要圖層、視窗圖層、win_fn_layer 和 win_media_layer 的按鍵綁定
- 變更 Main、Windows、WinFN、WinMedia、Mac、MacFN 和 MacMedia 的顯示名稱
- 移除登入和 fn_no_symbol 圖層的過時註釋和綁定

Signed-off-by: OfficePC <jackie@dast.tw>
