### PR TITLE
重構: 在多種鍵盤配置中重構鍵綁定

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -160,11 +160,11 @@
             display-name = "WinFN";
             label = "WinFN";
             bindings = <
-&kp ESC         &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                           &kp BSLH  &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
-&kp GRAVE       &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                      &kp N7    &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
-&kp LEFT_SHIFT  &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                            &kp N4    &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
-&kp LSHFT       &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &to WinMedia    &kp SEMI  &kp N1    &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
-                                                &kp LCTRL     &none                 &kp SQT                &kp COMMA       &kp DOT   &to Main  &kp N0     &kp FSLH
+&kp ESC    &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                           &kp BSLH  &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
+&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                      &kp N7    &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
+&kp TAB    &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                            &kp N4    &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
+&kp LSHFT  &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &to WinMedia    &kp SEMI  &kp N1    &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
+                                           &kp LCTRL     &none                 &kp SQT                &kp COMMA       &kp DOT   &to Main  &kp N0     &kp FSLH
             >;
         };
 
@@ -196,11 +196,11 @@
             display-name = "MacFN";
             label = "MacFN";
             bindings = <
-&kp ESC         &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                           &kp BSLH       &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
-&kp GRAVE       &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                      &kp N7         &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
-&kp LEFT_SHIFT  &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                            &kp N4         &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
-&kp LSHFT       &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &to MacMedia    &kp SEMI  &kp N1         &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
-                                                &kp LCTRL     &none                 &kp SQT                &kp COMMA       &kp DOT   &kp BACKSPACE  &kp N0     &kp FSLH
+&kp ESC    &kp F1           &kp F2         &kp LA(F4)    &kp F5                &kp F9                                           &kp BSLH       &kp SLASH  &kp KP_MULTIPLY  &kp MINUS  &kp HOME   &kp END
+&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN    &kp POUND     &kp DOLLAR            &kp PERCENT                                      &kp N7         &kp N8     &kp N9           &kp EQUAL  &kp PG_UP  &kp PG_DN
+&kp TAB    &kp CARET        &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS                            &kp N4         &kp N5     &kp N6           &kp RET    &kp UP     &kp BACKSPACE
+&kp LSHFT  &kp Z            &kp X          &kp C         &kp LBKT              &kp RBKT               &to MacMedia    &kp SEMI  &kp N1         &kp N2     &kp N3           &kp LEFT   &kp DOWN   &kp RIGHT
+                                           &kp LCTRL     &none                 &kp SQT                &kp COMMA       &kp DOT   &kp BACKSPACE  &kp N0     &kp FSLH
             >;
         };
 


### PR DESCRIPTION
- 更新Lily58鍵盤的按鍵映射配置，修改不同按鍵的繫結
- 更改shift、tab以及其他各種按鍵的繫結
- 調整WinMedia和MacMedia使用的按鍵映射配置
- 重新設計和排列按鍵映射配置中的鍵綁定格式

Signed-off-by: OfficePC <jackie@dast.tw>
