### PR TITLE
功能: 在輸入處理中增強鍵綁定配置

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -152,12 +152,15 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+                <&macro_press>,
+                <&kp LWIN>,
                 <&macro_tap>,
-                <&kp LG(X)>,
-                <&macro_wait_time 50>,
+                <&kp X>,
+                <&macro_release>,
+                <&kp LWIN>,
+                <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp U>,
-                <&macro_tap_time 50>,
                 <&macro_tap>,
                 <&kp R>;
 


### PR DESCRIPTION
- 將宏按下macro_press和kp LWIN添加到鍵綁定中
- 從鍵綁定中刪除kp LG(X)和宏等待時間50
- 將kp X、宏釋放、kp LWIN和宏暫停釋放添加到鍵綁定中
- 從鍵綁定中刪除宏輕觸時間50

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
